### PR TITLE
README: fix links rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Binc is a lightweight, compact, limitless, schema-free, precise, binary,
 high-performance, feature-rich, language-independent, multi-domain,
 extensible, data interchange format for structured data.
 
-The spec is available at [SPEC.md]
-(http://github.com/ugorji/binc/blob/master/SPEC.md). 
+The spec is available at
+[SPEC.md](http://github.com/ugorji/binc/blob/master/SPEC.md). 
 It is currently at version 0.3.0. 
-Binc adheres to the [Semantic Versioning] (http://semver.org/) standard.
+Binc adheres to the [Semantic Versioning](http://semver.org/) standard.
 
-Answers to frequently asked questions are available at [FAQ.md]
-(http://github.com/ugorji/binc/blob/master/FAQ.md).
+Answers to frequently asked questions are available at
+[FAQ.md](http://github.com/ugorji/binc/blob/master/FAQ.md).
 
 For more reading, see blog posts announcing and describing it below:
 


### PR DESCRIPTION
Apparently, current version of github markdown does not allow
for spaces between [TEXT] and (url) when rendering a link.